### PR TITLE
ユーザー新規登録機能 / フロントとバックエンドの連携

### DIFF
--- a/app/javascript/components/register/RegisterPage.vue
+++ b/app/javascript/components/register/RegisterPage.vue
@@ -2,9 +2,9 @@
   <div>
     <h1>新規ユーザー登録</h1>
     <v-form @submit.prevent="createUser">
-      <div v-if="errors.length != 0">
+      <div v-if="errors.errorMessages.length != 0">
         <ul
-          v-for="e in errors"
+          v-for="e in errors.errorMessages"
           :key="e"
         >
           <li>{{ e }}</li>
@@ -47,6 +47,12 @@
 
 <script>
 import axios from 'axios';
+axios.defaults.headers.common = {
+  'X-Requested-With': 'XMLHttpRequest',
+  'X-CSRF-TOKEN': document
+    .querySelector('meta[name="csrf-token"]')
+    .getAttribute('content')
+};
 
 export default {
   data() {
@@ -57,23 +63,25 @@ export default {
         password: '',
         password_confirmation: ''
       },
-      errors: ''
+      errors: {
+        message: '',
+        errorMessages: []
+      }
     };
   },
   methods: {
     createUser() {
       axios
-        .post('api/v1/registration', this.user)
+        .post('api/v1/registration', { user: this.user })
         .then(response => {
-          let e = response.data;
-          console.log(e);
-          // 画面遷移処理を後ほど追加
+          console.log(response.status);
+          // [ToDO] 遷移先を一時的にTopに、後に修正
+          this.$router.push({ name: 'TopPage' });
         })
         .catch(error => {
-          console.error(error);
-          if (error.response.data && error.response.data.errors) {
-            this.errors = error.response.data.errors;
-          }
+          let e = error.response;
+          console.error(e.status);
+          if (e.data.errors) { this.errors.errorMessages = e.data.errors; };
         });
     }
   }

--- a/app/javascript/components/register/RegisterPage.vue
+++ b/app/javascript/components/register/RegisterPage.vue
@@ -16,7 +16,7 @@
       />
       <v-text-field
         v-model="user.email"
-        label="Email"
+        label="メールアドレス"
       />
       <v-text-field
         v-model="user.password"

--- a/app/javascript/components/top/TopPage.vue
+++ b/app/javascript/components/top/TopPage.vue
@@ -1,12 +1,14 @@
 <template>
-  <div id="app">
-    <h1>{{ title }}</h1>
-    <p>
-      <router-link :to="{ name: 'RegisterPage' }">
-        to register
-      </router-link>
-    </p>
-  </div>
+  <v-app>
+    <v-main>
+      <h1>{{ title }}</h1>
+      <p>
+        <router-link :to="{ name: 'RegisterPage' }">
+          to register
+        </router-link>
+      </p>
+    </v-main>
+  </v-app>
 </template>
 
 <script>

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,9 +4,12 @@ class User < ApplicationRecord
   enum role: { general: 0, admin: 10 }
 
   with_options presence: true do
-    validates :name
+    validates :name, length: { maximum: 50 }
     validates :email, uniqueness: true
   end
+  validates :password, length: { minimum: 5 }, if: -> { new_record? || changes[:crypted_password] }
+  validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
+  validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 end
 
 # == Schema Information

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -1,0 +1,11 @@
+ja:
+  activerecord:
+    models:
+      user: "ユーザー"
+    attributes:
+      user:
+        name: "ユーザーネーム"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード（確認）"
+        role: "権限"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     sequence(:name, "name_0")
     sequence(:email) { |n| "user_#{n}@example.com" }
     password { "password" }
+    password_confirmation { "password" }
     role { 0 }
   end
 end

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe "Registrations", type: :request do
-  describe "GET /create" do
+  describe "POST /create" do
     context "有効な属性値の場合" do
-      it "ユーザーを追加できること" do
+      it "ユーザー新規作成に成功すること" do
         valid_params = attributes_for(:user)
 
         expect {
@@ -14,32 +14,60 @@ RSpec.describe "Registrations", type: :request do
     end
 
     context "無効な属性値の場合" do
-      it "名前がない場合ユーザーを追加できないこと" do
-        without_name_params = attributes_for(:user, name: "")
+      context "ユーザーネームの値がない場合" do
+        it "ユーザー新規作成に失敗すること" do
+          without_name_params = attributes_for(:user, name: "")
 
-        expect {
-          post "/api/v1/registration", params: { user: without_name_params }
-        }.to change(User, :count).by(0)
-        expect(response).to have_http_status("400")
+          expect {
+            post "/api/v1/registration", params: { user: without_name_params }
+          }.to change(User, :count).by(0)
+          expect(response).to have_http_status("400")
+        end
       end
 
-      it "メールアドレスがない場合ユーザーを追加できないこと" do
-        without_email_params = attributes_for(:user, email: "")
+      context "メールアドレスの値がない場合" do
+        it "ユーザー新規作成に失敗すること" do
+          without_email_params = attributes_for(:user, email: "")
 
-        expect {
-          post "/api/v1/registration", params: { user: without_email_params }
-        }.to change(User, :count).by(0)
-        expect(response).to have_http_status("400")
+          expect {
+            post "/api/v1/registration", params: { user: without_email_params }
+          }.to change(User, :count).by(0)
+          expect(response).to have_http_status("400")
+        end
       end
 
-      it "重複したメールアドレスの場合ユーザーを追加できないこと" do
-        other_user = create(:user)
-        duplicate_email_params = attributes_for(:user, email: other_user.email)
+      context "登録済みのメールアドレスを使用した場合" do
+        it "ユーザー新規作成に失敗すること" do
+          other_user = create(:user)
+          duplicate_email_params = attributes_for(:user, email: other_user.email)
 
-        expect {
-          post "/api/v1/registration", params: { user: duplicate_email_params }
-        }.to change(User, :count).by(0)
-        expect(response).to have_http_status("400")
+          expect {
+            post "/api/v1/registration", params: { user: duplicate_email_params }
+          }.to change(User, :count).by(0)
+          expect(response).to have_http_status("400")
+        end
+      end
+
+      context "パスワードの値がない場合" do
+        it "ユーザー新規作成に失敗すること" do
+          without_password_params = attributes_for(:user, password: "")
+
+          expect {
+            post "/api/v1/registration", params: { user: without_password_params }
+          }.to change(User, :count).by(0)
+          expect(response).to have_http_status("400")
+        end
+      end
+
+      context "パスワード（確認）の値がない場合" do
+        it "ユーザー新規作成に失敗すること" do
+          without_password_confirmation_params = attributes_for(:user, password_confirmation: "")
+
+          expect {
+            post "/api/v1/registration", params: { user: without_password_confirmation_params }
+          }.to change(User, :count).by(0)
+          expect(response).to have_http_status("400")
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,9 +44,8 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-  # The settings below are suggested to provide a good initial experience
-  # with RSpec, but feel free to customize to your heart's content.
-
+# The settings below are suggested to provide a good initial experience
+# with RSpec, but feel free to customize to your heart's content.
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
@@ -54,6 +53,7 @@ RSpec.configure do |config|
   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   config.filter_run_when_matching :focus
 
+=begin
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
@@ -92,4 +92,5 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
+=end
 end

--- a/spec/views/top/index.html.erb_spec.rb
+++ b/spec/views/top/index.html.erb_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "top/index.html.erb", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
## 概要

既に作成してあったフロントエンドと、バックエンドとを連携させた。
フロント側ではRailsの対CSRF機能をパスするためのCSRF-TOKENの付与、
Rails側の変数名に合わせてVueデータの要素名、axiosメソッドの変数などを変更した。

バックエンド側ではsorceryの`password_confirmation`を使用するために必要な
バリデーションを、Userモデルに追加した。

## チェックリスト

- [x] バックエンドの修正
- [x] フロントエンドの修正
- [x] 動作確認

## コメント

Vueの画面をSystem specを使用してテストすることは、現時点ではできなかった。
しかしE2Eテストができないのは不安要素が多いため、方法は引き続き探していく。

closes #48