### PR TITLE
Vueのルート定義を独立したファイルに切り出し#52

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -1,39 +1,11 @@
 <template>
-  <div id="app">
-    <router-view />
-  </div>
+  <v-app>
+    <v-main>
+      <router-view />
+    </v-main>
+  </v-app>
 </template>
 
 <script>
-import Vue from 'vue';
-import VueRouter from 'vue-router';
-
-import TopPage from './components/top/TopPage.vue';
-import RegisterPage from './components/register/RegisterPage.vue';
-
-const router = new VueRouter({
-  mode: 'history',
-  routes: [
-    {
-      path: '/',
-      component: TopPage,
-      name: 'TopPage'
-    },
-    {
-      path: '/register',
-      component: RegisterPage,
-      name: 'RegisterPage'
-    }
-  ]
-});
-
-Vue.use(VueRouter);
-
-export default {
-  router
-};
+export default {};
 </script>
-
-<style scoped>
-
-</style>

--- a/app/javascript/components/top/TopPage.vue
+++ b/app/javascript/components/top/TopPage.vue
@@ -1,14 +1,12 @@
 <template>
-  <v-app>
-    <v-main>
-      <h1>{{ title }}</h1>
-      <p>
-        <router-link :to="{ name: 'RegisterPage' }">
-          to register
-        </router-link>
-      </p>
-    </v-main>
-  </v-app>
+  <div>
+    <h1>{{ title }}</h1>
+    <p>
+      <router-link :to="{ name: 'RegisterPage' }">
+        to register
+      </router-link>
+    </p>
+  </div>
 </template>
 
 <script>

--- a/app/javascript/packs/main.js
+++ b/app/javascript/packs/main.js
@@ -7,10 +7,12 @@
 
 import Vue from 'vue';
 import App from '../app.vue';
+import router from '../router/router';
 import vuetify from '../vty/vty';
 
 document.addEventListener('DOMContentLoaded', () => {
   const app = new Vue({
+    router,
     vuetify,
     render: h => h(App)
   }).$mount();

--- a/app/javascript/router/router.js
+++ b/app/javascript/router/router.js
@@ -1,0 +1,25 @@
+import Vue from 'vue';
+import VueRouter from 'vue-router';
+
+import TopPage from '../components/top/TopPage.vue';
+import RegisterPage from '../components/register/RegisterPage.vue';
+
+Vue.use(VueRouter);
+
+const router = new VueRouter({
+  mode: 'history',
+  routes: [
+    {
+      path: '/',
+      component: TopPage,
+      name: 'TopPage'
+    },
+    {
+      path: '/register',
+      component: RegisterPage,
+      name: 'RegisterPage'
+    }
+  ]
+});
+
+export default router;


### PR DESCRIPTION
## 概要

ここまで`app.vue`に記述していたvue-routerによるルート定義を、独立した`router,js`に切り出した。
またそれに伴い、`main.js`にルーティングを読み込むための記述を追加。


## チェックリスト

- [x] `router.js`の作成
- [x] 定義の移植
- [x] 動作確認

closes #52