### PR TITLE
ログイン用フォームを作成#13

### DIFF
--- a/app/controllers/api/v1/authentications_controller.rb
+++ b/app/controllers/api/v1/authentications_controller.rb
@@ -1,25 +1,22 @@
 module Api
   module V1
     class AuthenticationsController < BaseController
+      skip_before_action :require_login
+
       def create
-        @user = login(login_params[:email], login_params[:password])
+        @user = login(params[:user][:email], params[:user][:password])
 
         if @user
           head :ok
         else
-          render400(nil, "Bad Request")
+          render400(nil, "ログインに失敗しました")
         end
       end
 
       def destroy
-        head :ok if logout
+        logout
+        head :ok
       end
-
-      private
-
-        def login_params
-          login_params = params[:user]
-        end
     end
   end
 end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class BaseController < ApplicationController
+      before_action :require_login
+
       rescue_from StandardError, with: :render500
       rescue_from ActiveRecord::RecordNotFound, with: :render404
 

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class RegistrationsController < BaseController
+      skip_before_action :require_login
+
       def create
         user = User.new(user_params)
 

--- a/app/javascript/components/pages/login/LoginModal.vue
+++ b/app/javascript/components/pages/login/LoginModal.vue
@@ -1,0 +1,136 @@
+<template>
+  <v-row justify="center">
+    <v-dialog
+      v-model="dialog"
+      max-width="600"
+    >
+      <template #activator="{ on }">
+        <v-btn
+          text
+          v-on="on"
+        >
+          login
+        </v-btn>
+      </template>
+      <v-card
+        flat
+        outlined
+      >
+        <v-card-title>
+          <div class="text-4">
+            ログイン
+          </div>
+        </v-card-title>
+        <validation-observer
+          ref="observer"
+          v-slot="{ handleSubmit }"
+        >
+          <v-form @submit.prevent="handleSubmit(loginUser)">
+            <v-card-text>
+              <div v-if="railsErrors.errorMessages.length != 0">
+                <v-alert
+                  v-for="e in railsErrors.errorMessages"
+                  :key="e"
+                  class="text-center"
+                  dense
+                  type="error"
+                >
+                  <v-row>
+                    <v-col>
+                      {{ e }}
+                    </v-col>
+                  </v-row>
+                </v-alert>
+              </div>
+              <v-row>
+                <v-col>
+                  <validation-provider
+                    v-slot="{ errors }"
+                    name="メールアドレス"
+                    rules="email|required"
+                  >
+                    <v-text-field
+                      v-model="user.email"
+                      :error-messages="errors"
+                      label="メールアドレス"
+                      type="email"
+                      required
+                    />
+                  </validation-provider>
+                </v-col>
+              </v-row>
+              <v-row>
+                <v-col>
+                  <validation-provider
+                    v-slot="{ errors }"
+                    name="パスワード"
+                    rules="alpha_num|min:5|required"
+                  >
+                    <v-text-field
+                      v-model="user.password"
+                      :error-messages="errors"
+                      label="パスワード"
+                      type="password"
+                      required
+                    />
+                  </validation-provider>
+                </v-col>
+              </v-row>
+            </v-card-text>
+            <v-card-actions>
+              <v-row class="text-center">
+                <v-col>
+                  <v-btn type="submit">
+                    ログイン
+                  </v-btn>
+                </v-col>
+                <v-col>
+                  <v-btn @click="dialog = false">
+                    キャンセル
+                  </v-btn>
+                </v-col>
+              </v-row>
+            </v-card-actions>
+          </v-form>
+        </validation-observer>
+      </v-card>
+    </v-dialog>
+  </v-row>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      dialog: false,
+      user: {
+        email: '',
+        password: ''
+      },
+      railsErrors: {
+        message: '',
+        errorMessages: []
+      }
+    };
+  },
+  methods: {
+    loginUser() {
+      this.axios
+        .post('api/v1/authentication', { user: this.user })
+        .then(response => {
+          console.log(response.status);
+          this.$store.commit('flashMessage/setMessage', {
+            type: 'success',
+            message: 'ログインしました'
+          });
+          this.dialog = false;
+        })
+        .catch(error => {
+          let e = error.response;
+          console.error(e.status);
+          if (e.data. errors ) { this.railsErrors.errorMessages = e.data. errors; };
+        });
+    }
+  }
+};
+</script>

--- a/app/javascript/components/pages/top/TopPage.vue
+++ b/app/javascript/components/pages/top/TopPage.vue
@@ -1,21 +1,65 @@
 <template>
   <div>
-    <h1>{{ title }}</h1>
-    <p>
-      <router-link :to="{ name: 'RegisterPage' }">
-        to register
-      </router-link>
-    </p>
+    <v-row>
+      <h1>{{ title }}</h1>
+    </v-row>
+    <!-- 一時的にリンクを設置、メニュー作成後移動 -->
+    <v-row>
+      <v-col>
+        <v-btn
+          text
+          :to="{ name: 'RegisterPage' }"
+        >
+          to register
+        </v-btn>
+      </v-col>
+      <v-col>
+        <login-modal />
+      </v-col>
+      <v-col>
+        <v-btn
+          @click="logoutUser"
+          text
+        >
+          logout
+        </v-btn>
+      </v-col>
+    </v-row>
+    <!-- ここまで -->
   </div>
 </template>
 
 <script>
+// ToDo: 一時的に設置、フッターメニュー作成後移動
+import LoginModal from '../login/LoginModal';
 
 export default {
+  components: {
+    // ToDo: 一時的に設置、フッターメニュー作成後移動
+    LoginModal
+  },
   data() {
     return {
       title: 'Dummy Top'
     };
+  },
+  methods: {
+    // ToDo: 一時的に設置、フッターメニュー作成後移動
+    logoutUser() {
+      this.axios
+        .delete('api/v1/authentication')
+        .then(response => {
+          console.log(response.status);
+          this.$store.commit('flashMessage/setMessage', {
+            type: 'success',
+            message: 'ログアウトしました'
+          });
+        })
+        .catch(error => {
+          let e = error.response;
+          console.error(e.status);
+        });
+    }
   }
 };
 </script>

--- a/spec/system/authentications_spec.rb
+++ b/spec/system/authentications_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe "Authentications", type: :system do
-  describe "ログイン" do
-    let(:user) { create(:user) }
+  let(:user) { create(:user) }
 
+  describe "ログイン" do
     before do
       visit "/"
       # リンク名は後々修正
-      click_link "to login"
+      click_button "login"
     end
 
     context "フォームの入力値が有効" do
@@ -30,11 +30,11 @@ RSpec.describe "Authentications", type: :system do
       end
 
       it "メールアドレスが間違っている場合、ログインに失敗すること" do
-        fill_in "メールアドレス", with: "unmatch"
+        fill_in "メールアドレス", with: "unmatch@example.com"
         fill_in "パスワード", with: "password"
         click_button "ログイン"
 
-        expect(page).to have_content ""
+        expect(page).to have_content "ログインに失敗しました"
       end
 
       it "パスワードが未入力の場合、ログインに失敗すること" do
@@ -50,14 +50,25 @@ RSpec.describe "Authentications", type: :system do
         fill_in "パスワード", with: "unmatch"
         click_button "ログイン"
 
-        expect(page).to have_content ""
+        expect(page).to have_content "ログインに失敗しました"
       end
     end
   end
 
   describe "ログアウト" do
     context "ログアウトボタンをクリック" do
-      it "ログアウト処理が成功する"
+      fit "ログアウト処理が成功する" do
+        visit "/"
+        # リンク名は後々修正
+        click_button "login"  
+        fill_in "メールアドレス", with: user.email
+        fill_in "パスワード", with: "password"
+        click_button "ログイン"
+        expect(page).to have_content "ログインしました"
+
+        click_button "logout"
+        expect(page).to have_content "ログアウトしました"
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要

ログイン用のフォームをモーダル形式で作成し、バックエンドと連携した。
ログイン前後での画面の出し訳などはまだ実装していないため、
次はissueの番号が入れ替わるが、フッターメニューの大枠を作成しそこで確認する。


## チェックリスト
- [x] `LoginPage.vue`の作成
- [x] template作成
- [x] script作成
- [x] バックエンドとの連携
- [x] 動作確認

closes #13