### PR TITLE
フッターメニューを作成#39

### DIFF
--- a/app/controllers/api/v1/authentications_controller.rb
+++ b/app/controllers/api/v1/authentications_controller.rb
@@ -7,7 +7,7 @@ module Api
         @user = login(params[:user][:email], params[:user][:password])
 
         if @user
-          head :ok
+          render json: { id: @user.id }
         else
           render400(nil, "ログインに失敗しました")
         end

--- a/app/controllers/api/v1/home_controller.rb
+++ b/app/controllers/api/v1/home_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class HomeController < BaseController
+      def index; end
+    end
+  end
+end

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -6,15 +6,18 @@
         <router-view />
       </v-container>
     </v-main>
+    <footer-menu />
   </v-app>
 </template>
 
 <script>
 import FlashMessage from './components/commons/FlashMessage';
+import FooterMenu from './components/commons/FooterMenu';
 
 export default {
   components: {
-    FlashMessage
+    FlashMessage,
+    FooterMenu
   }
 };
 </script>

--- a/app/javascript/components/commons/FooterMenu.vue
+++ b/app/javascript/components/commons/FooterMenu.vue
@@ -1,0 +1,34 @@
+<template>
+  <v-app-bar
+    app
+    bottom
+    color="blue"
+    fixed
+    flat
+  >
+    <v-container>
+      <v-row>
+        <footer-menu-item-after-login v-if="isLoggedIn === true" />
+        <footer-menu-item-before-login v-else />
+      </v-row>
+    </v-container>
+  </v-app-bar>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import FooterMenuItemAfterLogin from '../parts/FooterMenuItemAfterLogin';
+import FooterMenuItemBeforeLogin from '../parts/FooterMenuItemBeforeLogin';
+
+export default {
+  components: {
+    FooterMenuItemAfterLogin,
+    FooterMenuItemBeforeLogin
+  },
+  computed: {
+    ...mapState({
+      isLoggedIn: state => state.authUser.isLoggedIn
+    })
+  }
+};
+</script>

--- a/app/javascript/components/pages/home/HomePage.vue
+++ b/app/javascript/components/pages/home/HomePage.vue
@@ -1,0 +1,24 @@
+<template>
+  <div>
+    <h1 v-if="{userId}">
+      {{ userId }}
+    </h1>
+    <h1 v-else>
+      Null
+    </h1>
+    <h1>{{ isLoggedIn }}</h1>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+
+export default {
+  computed: {
+    ...mapState({
+      userId: state => state.authUser.userId,
+      isLoggedIn: state => state.authUser.isLoggedIn
+    })
+  }
+};
+</script>

--- a/app/javascript/components/pages/login/LoginModal.vue
+++ b/app/javascript/components/pages/login/LoginModal.vue
@@ -5,12 +5,17 @@
       max-width="600"
     >
       <template #activator="{ on }">
-        <v-btn
-          text
-          v-on="on"
-        >
-          login
-        </v-btn>
+        <v-row>
+          <v-col>
+            <v-btn
+              text
+              class="text-capitalize"
+              v-on="on"
+            >
+              login
+            </v-btn>
+          </v-col>
+        </v-row>
       </template>
       <v-card
         flat
@@ -119,16 +124,18 @@ export default {
         .post('api/v1/authentication', { user: this.user })
         .then(response => {
           console.log(response.status);
+          this.dialog = false;
+          this.$store.commit('authUser/login', response.data);
           this.$store.commit('flashMessage/setMessage', {
             type: 'success',
             message: 'ログインしました'
           });
-          this.dialog = false;
+          this.$router.push({ name: 'HomePage' });
         })
         .catch(error => {
           let e = error.response;
           console.error(e.status);
-          if (e.data. errors ) { this.railsErrors.errorMessages = e.data. errors; };
+          if (e.data.errors ) { this.railsErrors.errorMessages = e.data.errors; };
         });
     }
   }

--- a/app/javascript/components/pages/top/TopPage.vue
+++ b/app/javascript/components/pages/top/TopPage.vue
@@ -3,63 +3,15 @@
     <v-row>
       <h1>{{ title }}</h1>
     </v-row>
-    <!-- 一時的にリンクを設置、メニュー作成後移動 -->
-    <v-row>
-      <v-col>
-        <v-btn
-          text
-          :to="{ name: 'RegisterPage' }"
-        >
-          to register
-        </v-btn>
-      </v-col>
-      <v-col>
-        <login-modal />
-      </v-col>
-      <v-col>
-        <v-btn
-          @click="logoutUser"
-          text
-        >
-          logout
-        </v-btn>
-      </v-col>
-    </v-row>
-    <!-- ここまで -->
   </div>
 </template>
 
 <script>
-// ToDo: 一時的に設置、フッターメニュー作成後移動
-import LoginModal from '../login/LoginModal';
-
 export default {
-  components: {
-    // ToDo: 一時的に設置、フッターメニュー作成後移動
-    LoginModal
-  },
   data() {
     return {
       title: 'Dummy Top'
     };
-  },
-  methods: {
-    // ToDo: 一時的に設置、フッターメニュー作成後移動
-    logoutUser() {
-      this.axios
-        .delete('api/v1/authentication')
-        .then(response => {
-          console.log(response.status);
-          this.$store.commit('flashMessage/setMessage', {
-            type: 'success',
-            message: 'ログアウトしました'
-          });
-        })
-        .catch(error => {
-          let e = error.response;
-          console.error(e.status);
-        });
-    }
   }
 };
 </script>

--- a/app/javascript/components/parts/FooterMenuItemAfterLogin.vue
+++ b/app/javascript/components/parts/FooterMenuItemAfterLogin.vue
@@ -1,0 +1,46 @@
+<template>
+  <v-row>
+    <v-col>
+      <v-btn
+        :to="{ name: 'HomePage' }"
+        text
+        class="text-capitalize"
+      >
+        Home
+      </v-btn>
+    </v-col>
+    <v-col>
+      <v-btn
+        text
+        class="text-capitalize"
+        @click="logoutUser"
+      >
+        logout
+      </v-btn>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+export default {
+  methods: {
+    logoutUser() {
+      this.axios
+        .delete('api/v1/authentication')
+        .then(response => {
+          console.log(response.status);
+          this.$store.commit('authUser/RESET_AUTHUSER_STATE');
+          this.$store.commit('flashMessage/setMessage', {
+            type: 'success',
+            message: 'ログアウトしました'
+          });
+          this.$router.push({ name: 'TopPage' });
+        })
+        .catch(error => {
+          let e = error.response;
+          console.error(e.status);
+        });
+    }
+  }
+};
+</script>

--- a/app/javascript/components/parts/FooterMenuItemBeforeLogin.vue
+++ b/app/javascript/components/parts/FooterMenuItemBeforeLogin.vue
@@ -1,0 +1,35 @@
+<template>
+  <v-row>
+    <v-col>
+      <v-btn
+        :to="{ name: 'TopPage' }"
+        text
+        class="text-capitalize"
+      >
+        Top
+      </v-btn>
+    </v-col>
+    <v-col>
+      <v-btn
+        :to="{ name: 'RegisterPage' }"
+        text
+        class="text-capitalize"
+      >
+        register
+      </v-btn>
+    </v-col>
+    <v-col>
+      <login-modal />
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+import LoginModal from '../pages/login/LoginModal';
+
+export default {
+  components: {
+    LoginModal
+  }
+};
+</script>

--- a/app/javascript/packs/main.js
+++ b/app/javascript/packs/main.js
@@ -14,6 +14,7 @@ import AxiosPlugin from '../plugins/axiosPlugin';
 import vuetify from '../vty/vty';
 import * as veeValidate from '../plugins/vee-validate';
 import store from '../store/index';
+import { initialState } from '../store/modules/authUser';
 
 Vue.use(AxiosPlugin, { axios: axios, csrfToken: csrfToken });
 
@@ -23,6 +24,9 @@ document.addEventListener('DOMContentLoaded', () => {
     vuetify,
     veeValidate,
     store,
+    created() {
+      localStorage.setItem('initialState', JSON.stringify(initialState));
+    },
     render: h => h(App)
   }).$mount();
   document.body.appendChild(app.$el);

--- a/app/javascript/router/router.js
+++ b/app/javascript/router/router.js
@@ -1,8 +1,9 @@
 import Vue from 'vue';
 import VueRouter from 'vue-router';
 
-import TopPage from '../components/pages/top/TopPage.vue';
-import RegisterPage from '../components/pages/register/RegisterPage.vue';
+import TopPage from '../components/pages/top/TopPage';
+import RegisterPage from '../components/pages/register/RegisterPage';
+import HomePage from '../components/pages/home/HomePage';
 
 Vue.use(VueRouter);
 
@@ -18,6 +19,11 @@ const router = new VueRouter({
       path: '/register',
       component: RegisterPage,
       name: 'RegisterPage'
+    },
+    {
+      path: '/home',
+      component: HomePage,
+      name: 'HomePage'
     }
   ]
 });

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -1,14 +1,26 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
+import createPersistedState from 'vuex-persistedstate';
 
 import flashMessage from './modules/flashMessage';
+import authUser from './modules/authUser';
 
 Vue.use(Vuex);
 
 const store = new Vuex.Store({
   modules: {
-    flashMessage
-  }
+    flashMessage,
+    authUser
+  },
+
+  plugins: [createPersistedState({
+    key: 'iHateToEat',
+    paths: [
+      'authUser.userId',
+      'authUser.isLoggedIn'
+    ],
+    storage: window.localStorage
+  })]
 });
 
 export default store;

--- a/app/javascript/store/modules/authUser.js
+++ b/app/javascript/store/modules/authUser.js
@@ -1,0 +1,20 @@
+export const initialState = {
+  userId: '',
+  isLoggedIn: false
+};
+
+const mutations = {
+  RESET_AUTHUSER_STATE(state) {
+    Object.assign(state, JSON.parse(localStorage.getItem('initialState')));
+  },
+  login(state, userId) {
+    state.userId = userId.id;
+    state.isLoggedIn = true;
+  }
+};
+
+export default {
+  namespaced: true,
+  state: initialState,
+  mutations,
+};

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resource :registration, only: %i[create]
       resource :authentication, only: %i[create destroy]
+      resources :home, only: %i[index]
     end
   end
 end

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "vue-router": "^3.5.2",
     "vue-template-compiler": "^2.6.14",
     "vuetify": "^2.5.8",
-    "vuex": "^3.6.2"
+    "vuex": "^3.6.2",
+    "vuex-persistedstate": "^4.0.0"
   },
   "version": "0.1.0",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2669,6 +2669,11 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 default-gateway@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-4.2.0.tgz#167104c7500c2115f6dd69b0a536bb8ed720552b"
@@ -7066,6 +7071,11 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+shvl@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/shvl/-/shvl-2.0.3.tgz#eb4bd37644f5684bba1fc52c3010c96fb5e6afd1"
+  integrity sha512-V7C6S9Hlol6SzOJPnQ7qzOVEWUQImt3BNmmzh40wObhla3XOYMe4gGiYzLrJd5TFa+cI2f9LKIRJTTKZSTbWgw==
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -8038,6 +8048,14 @@ vuetify@^2.5.8:
   version "2.5.8"
   resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-2.5.8.tgz#a23e6a7e77b77de0744b53cf1e7c9d40efac0635"
   integrity sha512-paLmNhKTYFD41+14rIHnCo+P1jHbUzwBiMowxs5qXVq8RdRMqRmcy05Sfse1WUu90amPGK2fIFQq5rL2N8zqZg==
+
+vuex-persistedstate@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/vuex-persistedstate/-/vuex-persistedstate-4.0.0.tgz#ed82f266ca98c869a2aad9cb9880c2f608c05f3a"
+  integrity sha512-jDs+awbV9YD2A2F6S5zgtYq1Bjd8v0YldOK6HPv1EJZzGMse0FtZTREfXvA7zlVfq9MpmSZJNmYQVylfpZ5znQ==
+  dependencies:
+    deepmerge "^4.2.2"
+    shvl "^2.0.3"
 
 vuex@^3.6.2:
   version "3.6.2"


### PR DESCRIPTION
## 概要

フッターメニューを作成。メニュー内に表示するコンテンツをログインの前後で分けられるよう、
メニュー内容のコンポーネントを２種類作成した。
また、フロントでログインユーザーの有無を判定するために、authUserステートを追加。
ユーザー情報はローカルストレージに保存し、現状ログアウト処理を行わない限りは
消えないようにしてある。

## チェックリスト

- [x] フッターメニューの大枠を作成
- [x] 既存のリンク・ボタンをフッターに移動
- [x] ログインの前後で表示するコンテンツを出し分ける処理を追加
- [x] 動作確認

closes #39