### PR TITLE
ヘッダーの大枠を作成#38

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app>
+    <common-header />
     <v-main>
-      <flash-message />
       <v-container>
         <router-view />
       </v-container>
@@ -11,12 +11,12 @@
 </template>
 
 <script>
-import FlashMessage from './components/commons/FlashMessage';
+import CommonHeader from './components/commons/CommonHeader';
 import FooterMenu from './components/commons/FooterMenu';
 
 export default {
   components: {
-    FlashMessage,
+    CommonHeader,
     FooterMenu
   }
 };

--- a/app/javascript/components/commons/CommonHeader.vue
+++ b/app/javascript/components/commons/CommonHeader.vue
@@ -1,0 +1,37 @@
+<template>
+  <v-app-bar
+    app
+    color="blue"
+    flat
+    fixed
+    height="100"
+  >
+    <v-row>
+      <flash-message />
+    </v-row>
+    <v-row>
+      <v-col>
+        <v-card
+          color="red"
+          flat
+          width="300px"
+          height="50px"
+        >
+          <div class="text-center text-h3">
+            Ad
+          </div>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-app-bar>
+</template>
+
+<script>
+import FlashMessage from './FlashMessage';
+
+export default {
+  components: {
+    FlashMessage
+  }
+};
+</script>


### PR DESCRIPTION
## 概要

スペースをあらかじめ確保しておく目的で、ヘッダーの大枠を作成。
現状コンテンツは作成していないが、フラッシュメッセージの表示、
googleアドセンス の広告の表示に使用する予定。

## チェックリスト

- [x] 大枠を作成
- [x] 表示確認

closes #38