### PR TITLE
activeadminで管理画面を作成#8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,15 +2,19 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.7.4'
+
 gem 'rails', '~> 6.0.3', '>= 6.0.3.7'
-# Use mysql as the database for Active Record
+
+# Database
 gem 'mysql2', '>= 0.4.4'
-# Use Puma as the app server
+
+# App server
 gem 'puma', '~> 4.1'
-# Use SCSS for stylesheets
+
+# Assets
 gem 'sass-rails', '>= 6'
-# Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker', '~> 4.0'
+
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production
@@ -24,19 +28,42 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 
+# Authentication
 gem 'sorcery'
 
+# Configuration
+gem 'dotenv-rails'
+
+# Serializer
 gem 'fast_jsonapi'
 
+# UI/UX
 gem 'rails-i18n', '~> 6.0.0' 
 
+# Management portal
+gem 'activeadmin'
+
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  # Debugger
+  gem 'byebug'
+  gem 'pry'
   gem 'pry-rails'
   gem 'pry-byebug'
+  gem 'better_errors'
+  gem 'binding_of_caller'
+
+  # Print debug
   gem 'hirb'
   gem 'hirb-unicode-steakknife'
-  gem 'dotenv-rails'
+
+  # Code analyze
+  gem 'rubocop', require: false
+  gem 'rubocop-rails', require: false
+
+  # Table/Schema
+  gem 'annotate'
+
+  # Test
   gem 'rspec-rails', '~> 5.0.0'
   gem 'factory_bot_rails'
 end
@@ -45,15 +72,10 @@ group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '~> 3.2'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+
+  # CLI
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-
-  gem 'better_errors'
-  gem 'binding_of_caller'
-  gem 'rubocop', require: false
-  gem 'rubocop-rails', require: false
-  gem 'annotate'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'fast_jsonapi'
 
 # UI/UX
 gem 'rails-i18n', '~> 6.0.0' 
+gem 'enum_help'
 
 # Management portal
 gem 'activeadmin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,15 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activeadmin (2.9.0)
+      arbre (~> 1.2, >= 1.2.1)
+      formtastic (>= 3.1, < 5.0)
+      formtastic_i18n (~> 0.4)
+      inherited_resources (~> 1.7)
+      jquery-rails (~> 4.2)
+      kaminari (~> 1.0, >= 1.2.1)
+      railties (>= 5.2, < 6.2)
+      ransack (~> 2.1, >= 2.1.1)
     activejob (6.0.4.1)
       activesupport (= 6.0.4.1)
       globalid (>= 0.3.6)
@@ -61,6 +70,9 @@ GEM
     annotate (3.1.1)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
+    arbre (1.4.0)
+      activesupport (>= 3.0.0, < 6.2)
+      ruby2_keywords (>= 0.0.2, < 1.0)
     ast (2.4.2)
     bcrypt (3.1.16)
     better_errors (2.9.1)
@@ -120,17 +132,44 @@ GEM
     fast_jsonapi (1.5)
       activesupport (>= 4.2)
     ffi (1.15.3)
+    formtastic (4.0.0)
+      actionpack (>= 5.2.0)
+    formtastic_i18n (0.7.0)
     globalid (0.5.2)
       activesupport (>= 5.0)
+    has_scope (0.8.0)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
     hirb (0.7.3)
     hirb-unicode-steakknife (0.0.9)
       hirb (~> 0.5)
       unicode-display_width (~> 1.1)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    inherited_resources (1.13.0)
+      actionpack (>= 5.2, < 6.2)
+      has_scope (~> 0.6)
+      railties (>= 5.2, < 6.2)
+      responders (>= 2, < 4)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    jquery-rails (4.4.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     jwt (2.2.3)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -211,10 +250,17 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     rake (13.0.6)
+    ransack (2.4.2)
+      activerecord (>= 5.2.4)
+      activesupport (>= 5.2.4)
+      i18n
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.1.1)
+    responders (3.0.1)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     rexml (3.2.5)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
@@ -309,10 +355,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activeadmin
   annotate
   better_errors
   binding_of_caller
   bootsnap (>= 1.4.2)
+  byebug
   capybara
   dotenv-rails
   factory_bot_rails
@@ -322,6 +370,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (~> 3.2)
   mysql2 (>= 0.4.4)
+  pry
   pry-byebug
   pry-rails
   puma (~> 4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
@@ -363,6 +365,7 @@ DEPENDENCIES
   byebug
   capybara
   dotenv-rails
+  enum_help
   factory_bot_rails
   fast_jsonapi
   hirb

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -1,0 +1,32 @@
+ActiveAdmin.register_page "Dashboard" do
+  menu priority: 1, label: proc { I18n.t("active_admin.dashboard") }
+
+  content title: proc { I18n.t("active_admin.dashboard") } do
+    div class: "blank_slate_container", id: "dashboard_default_message" do
+      span class: "blank_slate" do
+        span I18n.t("active_admin.dashboard_welcome.welcome")
+        small I18n.t("active_admin.dashboard_welcome.call_to_action")
+      end
+    end
+
+    # Here is an example of a simple dashboard with columns and panels.
+    #
+    # columns do
+    #   column do
+    #     panel "Recent Posts" do
+    #       ul do
+    #         Post.recent(5).map do |post|
+    #           li link_to(post.title, admin_post_path(post))
+    #         end
+    #       end
+    #     end
+    #   end
+
+    #   column do
+    #     panel "Info" do
+    #       para "Welcome to ActiveAdmin."
+    #     end
+    #   end
+    # end
+  end # content
+end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,0 +1,44 @@
+ActiveAdmin.register User do
+  permit_params :name, :email, :password, :password_confirmation, :role
+
+  # 一覧ページの表示項目
+  index do
+    selectable_column
+    id_column
+    column :name
+    column :email
+    column :role
+    actions
+  end
+
+  # 一覧ページのフィルター項目
+  filter :name
+  filter :email
+  filter :role
+  filter :created_at
+  filter :updated_at
+
+  # 詳細ページの表示項目
+  show do
+    attributes_table do
+      row(:id)
+      row(:name)
+      row(:email)
+      row(:role)
+      row(:created_at)
+      row(:updated_at)
+    end
+  end
+
+  # フォームの入力項目
+  form do |f|
+    f.inputs do
+      f.input :name
+      f.input :email
+      f.input :password
+      f.input :password_confirmation
+      f.input :role        
+    end
+    f.actions
+  end
+end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -5,16 +5,18 @@ ActiveAdmin.register User do
   index do
     selectable_column
     id_column
-    column :name
-    column :email
-    column :role
+    column(:name)
+    column(:email)
+    column(:role) do |user|
+      user.role_i18n
+    end
     actions
   end
 
   # 一覧ページのフィルター項目
   filter :name
   filter :email
-  filter :role
+  filter :role, as: :select, collection: User.roles_i18n.invert.map{ |key, value| [key, User.roles[value]]}
   filter :created_at
   filter :updated_at
 
@@ -24,7 +26,9 @@ ActiveAdmin.register User do
       row(:id)
       row(:name)
       row(:email)
-      row(:role)
+      row(:role) do |user|
+        user.role_i18n
+      end
       row(:created_at)
       row(:updated_at)
     end
@@ -37,7 +41,7 @@ ActiveAdmin.register User do
       f.input :email
       f.input :password
       f.input :password_confirmation
-      f.input :role        
+      f.input :role, collection: User.roles_i18n.invert
     end
     f.actions
   end

--- a/app/javascript/packs/active_admin.js
+++ b/app/javascript/packs/active_admin.js
@@ -1,0 +1,5 @@
+// Load Active Admin's styles into Webpacker,
+// see `active_admin.scss` for customization.
+import "../stylesheets/active_admin";
+
+import "@activeadmin/activeadmin";

--- a/app/javascript/packs/active_admin/print.scss
+++ b/app/javascript/packs/active_admin/print.scss
@@ -1,0 +1,2 @@
+/* Active Admin Print Stylesheet */
+@import "~@activeadmin/activeadmin/src/scss/print";

--- a/app/javascript/stylesheets/active_admin.scss
+++ b/app/javascript/stylesheets/active_admin.scss
@@ -1,0 +1,17 @@
+// Sass variable overrides must be declared before loading up Active Admin's styles.
+//
+// To view the variables that Active Admin provides, take a look at
+// `app/assets/stylesheets/active_admin/mixins/_variables.scss` in the
+// Active Admin source.
+//
+// For example, to change the sidebar width:
+// $sidebar-width: 242px;
+
+// Active Admin's got SASS!
+@import "~@activeadmin/activeadmin/src/scss/mixins";
+@import "~@activeadmin/activeadmin/src/scss/base";
+
+// Overriding any non-variable Sass must be done after the fact.
+// For example, to change the default status-tag color:
+//
+//   .status_tag { background: #6090DB; }

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -1,0 +1,335 @@
+ActiveAdmin.setup do |config|
+  # == Site Title
+  #
+  # Set the title that is displayed on the main layout
+  # for each of the active admin pages.
+  #
+  config.site_title = "I Hate To Eat"
+
+  # Set the link url for the title. For example, to take
+  # users to your main site. Defaults to no link.
+  #
+  # config.site_title_link = "/"
+
+  # Set an optional image to be displayed for the header
+  # instead of a string (overrides :site_title)
+  #
+  # Note: Aim for an image that's 21px high so it fits in the header.
+  #
+  # config.site_title_image = "logo.png"
+
+  # == Default Namespace
+  #
+  # Set the default namespace each administration resource
+  # will be added to.
+  #
+  # eg:
+  #   config.default_namespace = :hello_world
+  #
+  # This will create resources in the HelloWorld module and
+  # will namespace routes to /hello_world/*
+  #
+  # To set no namespace by default, use:
+  #   config.default_namespace = false
+  #
+  # Default:
+  # config.default_namespace = :admin
+  #
+  # You can customize the settings for each namespace by using
+  # a namespace block. For example, to change the site title
+  # within a namespace:
+  #
+  #   config.namespace :admin do |admin|
+  #     admin.site_title = "Custom Admin Title"
+  #   end
+  #
+  # This will ONLY change the title for the admin section. Other
+  # namespaces will continue to use the main "site_title" configuration.
+
+  # == User Authentication
+  #
+  # Active Admin will automatically call an authentication
+  # method in a before filter of all controller actions to
+  # ensure that there is a currently logged in admin user.
+  #
+  # This setting changes the method which Active Admin calls
+  # within the application controller.
+  # config.authentication_method = :authenticate_admin_user!
+
+  # == User Authorization
+  #
+  # Active Admin will automatically call an authorization
+  # method in a before filter of all controller actions to
+  # ensure that there is a user with proper rights. You can use
+  # CanCanAdapter or make your own. Please refer to documentation.
+  # config.authorization_adapter = ActiveAdmin::CanCanAdapter
+
+  # In case you prefer Pundit over other solutions you can here pass
+  # the name of default policy class. This policy will be used in every
+  # case when Pundit is unable to find suitable policy.
+  # config.pundit_default_policy = "MyDefaultPunditPolicy"
+
+  # If you wish to maintain a separate set of Pundit policies for admin
+  # resources, you may set a namespace here that Pundit will search
+  # within when looking for a resource's policy.
+  # config.pundit_policy_namespace = :admin
+
+  # You can customize your CanCan Ability class name here.
+  # config.cancan_ability_class = "Ability"
+
+  # You can specify a method to be called on unauthorized access.
+  # This is necessary in order to prevent a redirect loop which happens
+  # because, by default, user gets redirected to Dashboard. If user
+  # doesn't have access to Dashboard, he'll end up in a redirect loop.
+  # Method provided here should be defined in application_controller.rb.
+  # config.on_unauthorized_access = :access_denied
+
+  # == Current User
+  #
+  # Active Admin will associate actions with the current
+  # user performing them.
+  #
+  # This setting changes the method which Active Admin calls
+  # (within the application controller) to return the currently logged in user.
+  # config.current_user_method = :current_admin_user
+
+  # == Logging Out
+  #
+  # Active Admin displays a logout link on each screen. These
+  # settings configure the location and method used for the link.
+  #
+  # This setting changes the path where the link points to. If it's
+  # a string, the strings is used as the path. If it's a Symbol, we
+  # will call the method to return the path.
+  #
+  # Default:
+  config.logout_link_path = :destroy_admin_user_session_path
+
+  # This setting changes the http method used when rendering the
+  # link. For example :get, :delete, :put, etc..
+  #
+  # Default:
+  # config.logout_link_method = :get
+
+  # == Root
+  #
+  # Set the action to call for the root path. You can set different
+  # roots for each namespace.
+  #
+  # Default:
+  # config.root_to = 'dashboard#index'
+
+  # == Admin Comments
+  #
+  # This allows your users to comment on any resource registered with Active Admin.
+  #
+  # You can completely disable comments:
+  # config.comments = false
+  #
+  # You can change the name under which comments are registered:
+  # config.comments_registration_name = 'AdminComment'
+  #
+  # You can change the order for the comments and you can change the column
+  # to be used for ordering:
+  # config.comments_order = 'created_at ASC'
+  #
+  # You can disable the menu item for the comments index page:
+  # config.comments_menu = false
+  #
+  # You can customize the comment menu:
+  # config.comments_menu = { parent: 'Admin', priority: 1 }
+
+  # == Batch Actions
+  #
+  # Enable and disable Batch Actions
+  #
+  config.batch_actions = true
+
+  # == Controller Filters
+  #
+  # You can add before, after and around filters to all of your
+  # Active Admin resources and pages from here.
+  #
+  # config.before_action :do_something_awesome
+
+  # == Attribute Filters
+  #
+  # You can exclude possibly sensitive model attributes from being displayed,
+  # added to forms, or exported by default by ActiveAdmin
+  #
+  config.filter_attributes = [:encrypted_password, :password, :password_confirmation]
+
+  # == Localize Date/Time Format
+  #
+  # Set the localize format to display dates and times.
+  # To understand how to localize your app with I18n, read more at
+  # https://guides.rubyonrails.org/i18n.html
+  #
+  # You can run `bin/rails runner 'puts I18n.t("date.formats")'` to see the
+  # available formats in your application.
+  #
+  config.localize_format = :long
+
+  # == Setting a Favicon
+  #
+  # config.favicon = 'favicon.ico'
+
+  # == Meta Tags
+  #
+  # Add additional meta tags to the head element of active admin pages.
+  #
+  # Add tags to all pages logged in users see:
+  #   config.meta_tags = { author: 'My Company' }
+
+  # By default, sign up/sign in/recover password pages are excluded
+  # from showing up in search engine results by adding a robots meta
+  # tag. You can reset the hash of meta tags included in logged out
+  # pages:
+  #   config.meta_tags_for_logged_out_pages = {}
+
+  # == Removing Breadcrumbs
+  #
+  # Breadcrumbs are enabled by default. You can customize them for individual
+  # resources or you can disable them globally from here.
+  #
+  # config.breadcrumb = false
+
+  # == Create Another Checkbox
+  #
+  # Create another checkbox is disabled by default. You can customize it for individual
+  # resources or you can enable them globally from here.
+  #
+  # config.create_another = true
+
+  # == Register Stylesheets & Javascripts
+  #
+  # We recommend using the built in Active Admin layout and loading
+  # up your own stylesheets / javascripts to customize the look
+  # and feel.
+  #
+  # To load a stylesheet:
+  #   config.register_stylesheet 'my_stylesheet.css'
+  #
+  # You can provide an options hash for more control, which is passed along to stylesheet_link_tag():
+  #   config.register_stylesheet 'my_print_stylesheet.css', media: :print
+  #
+  # To load a javascript file:
+  #   config.register_javascript 'my_javascript.js'
+
+  # == CSV options
+  #
+  # Set the CSV builder separator
+  # config.csv_options = { col_sep: ';' }
+  #
+  # Force the use of quotes
+  # config.csv_options = { force_quotes: true }
+
+  # == Menu System
+  #
+  # You can add a navigation menu to be used in your application, or configure a provided menu
+  #
+  # To change the default utility navigation to show a link to your website & a logout btn
+  #
+  #   config.namespace :admin do |admin|
+  #     admin.build_menu :utility_navigation do |menu|
+  #       menu.add label: "My Great Website", url: "http://www.mygreatwebsite.com", html_options: { target: :blank }
+  #       admin.add_logout_button_to_menu menu
+  #     end
+  #   end
+  #
+  # If you wanted to add a static menu item to the default menu provided:
+  #
+  #   config.namespace :admin do |admin|
+  #     admin.build_menu :default do |menu|
+  #       menu.add label: "My Great Website", url: "http://www.mygreatwebsite.com", html_options: { target: :blank }
+  #     end
+  #   end
+
+  # == Download Links
+  #
+  # You can disable download links on resource listing pages,
+  # or customize the formats shown per namespace/globally
+  #
+  # To disable/customize for the :admin namespace:
+  #
+  #   config.namespace :admin do |admin|
+  #
+  #     # Disable the links entirely
+  #     admin.download_links = false
+  #
+  #     # Only show XML & PDF options
+  #     admin.download_links = [:xml, :pdf]
+  #
+  #     # Enable/disable the links based on block
+  #     #   (for example, with cancan)
+  #     admin.download_links = proc { can?(:view_download_links) }
+  #
+  #   end
+
+  # == Pagination
+  #
+  # Pagination is enabled by default for all resources.
+  # You can control the default per page count for all resources here.
+  #
+  # config.default_per_page = 30
+  #
+  # You can control the max per page count too.
+  #
+  # config.max_per_page = 10_000
+
+  # == Filters
+  #
+  # By default the index screen includes a "Filters" sidebar on the right
+  # hand side with a filter for each attribute of the registered model.
+  # You can enable or disable them for all resources here.
+  #
+  # config.filters = true
+  #
+  # By default the filters include associations in a select, which means
+  # that every record will be loaded for each association (up
+  # to the value of config.maximum_association_filter_arity).
+  # You can enabled or disable the inclusion
+  # of those filters by default here.
+  #
+  # config.include_default_association_filters = true
+
+  # config.maximum_association_filter_arity = 256 # default value of :unlimited will change to 256 in a future version
+  # config.filter_columns_for_large_association = [
+  #    :display_name,
+  #    :full_name,
+  #    :name,
+  #    :username,
+  #    :login,
+  #    :title,
+  #    :email,
+  #  ]
+  # config.filter_method_for_large_association = '_starts_with'
+
+  # == Head
+  #
+  # You can add your own content to the site head like analytics. Make sure
+  # you only pass content you trust.
+  #
+  # config.head = ''.html_safe
+
+  # == Footer
+  #
+  # By default, the footer shows the current Active Admin version. You can
+  # override the content of the footer here.
+  #
+  # config.footer = 'my custom footer text'
+
+  # == Sorting
+  #
+  # By default ActiveAdmin::OrderClause is used for sorting logic
+  # You can inherit it with own class and inject it for all resources
+  #
+  # config.order_clause = MyOrderClause
+
+  # == Webpacker
+  #
+  # By default, Active Admin uses Sprocket's asset pipeline.
+  # You can switch to using Webpacker here.
+  #
+  config.use_webpacker = true
+end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -54,7 +54,7 @@ ActiveAdmin.setup do |config|
   #
   # This setting changes the method which Active Admin calls
   # within the application controller.
-  # config.authentication_method = :authenticate_admin_user!
+  # config.authentication_method = :require_login
 
   # == User Authorization
   #
@@ -91,7 +91,7 @@ ActiveAdmin.setup do |config|
   #
   # This setting changes the method which Active Admin calls
   # (within the application controller) to return the currently logged in user.
-  # config.current_user_method = :current_admin_user
+  # config.current_user_method = :current_user
 
   # == Logging Out
   #
@@ -103,13 +103,13 @@ ActiveAdmin.setup do |config|
   # will call the method to return the path.
   #
   # Default:
-  config.logout_link_path = :destroy_admin_user_session_path
+  config.logout_link_path = :api_v1_authentication_path
 
   # This setting changes the http method used when rendering the
   # link. For example :get, :delete, :put, etc..
   #
   # Default:
-  # config.logout_link_method = :get
+  config.logout_link_method = :delete
 
   # == Root
   #

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -9,3 +9,10 @@ ja:
         password: "パスワード"
         password_confirmation: "パスワード（確認）"
         role: "権限"
+        created_at: "登録日時"
+        updated_at: "更新日時"
+  enums:
+    user:
+      role:
+        general: "一般"
+        admin: "管理者"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  ActiveAdmin.routes(self)
   root to: 'top#index'
 
   namespace :api, format: 'json' do

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,4 +1,5 @@
 const { environment } = require('@rails/webpacker')
+const jquery = require('./plugins/jquery')
 const { VueLoaderPlugin } = require('vue-loader')
 const vue = require('./loaders/vue')
 const eslint = require('./loaders/eslint')
@@ -6,4 +7,5 @@ const eslint = require('./loaders/eslint')
 environment.plugins.prepend('VueLoaderPlugin', new VueLoaderPlugin())
 environment.loaders.prepend('vue', vue)
 environment.loaders.append('eslint', eslint)
+environment.plugins.prepend('jquery', jquery)
 module.exports = environment

--- a/config/webpack/plugins/jquery.js
+++ b/config/webpack/plugins/jquery.js
@@ -1,0 +1,7 @@
+const webpack = require('webpack')
+
+module.exports = new webpack.ProvidePlugin({
+  "$":"jquery",
+  "jQuery":"jquery",
+  "window.jQuery":"jquery"
+});

--- a/db/migrate/20210831053126_create_active_admin_comments.rb
+++ b/db/migrate/20210831053126_create_active_admin_comments.rb
@@ -1,0 +1,16 @@
+class CreateActiveAdminComments < ActiveRecord::Migration[6.0]
+  def self.up
+    create_table :active_admin_comments do |t|
+      t.string :namespace
+      t.text   :body
+      t.references :resource, polymorphic: true
+      t.references :author, polymorphic: true
+      t.timestamps
+    end
+    add_index :active_admin_comments, [:namespace]
+  end
+
+  def self.down
+    drop_table :active_admin_comments
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_15_083324) do
+ActiveRecord::Schema.define(version: 2021_08_31_053126) do
+
+  create_table "active_admin_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "namespace"
+    t.text "body"
+    t.string "resource_type"
+    t.bigint "resource_id"
+    t.string "author_type"
+    t.bigint "author_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
+    t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
+    t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id"
+  end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "lint-fix": "yarn run eslint --fix --ext .vue --ext .js app/javascript"
   },
   "dependencies": {
+    "@activeadmin/activeadmin": "^2.9.0",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,15 @@
 # yarn lockfile v1
 
 
+"@activeadmin/activeadmin@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@activeadmin/activeadmin/-/activeadmin-2.9.0.tgz#ad277ef4a49b250377afd3df615f9acc3c84d577"
+  integrity sha512-KZqr1MrvpCXN/8SCF4MgqGscmuWPHivz5RPHKR9R8bKIB0InUHm7tzQoQOT9ZdYuHCBkf3cqlzBoKNNNV3x3ww==
+  dependencies:
+    jquery "^3.4.1"
+    jquery-ui "^1.12.1"
+    jquery-ujs "^1.2.2"
+
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
@@ -4477,6 +4486,21 @@ jest-worker@^25.4.0:
   dependencies:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
+
+jquery-ui@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.12.1.tgz#bcb4045c8dd0539c134bc1488cdd3e768a7a9e51"
+  integrity sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE=
+
+jquery-ujs@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/jquery-ujs/-/jquery-ujs-1.2.3.tgz#dcac6026ab7268e5ee41faf9d31c997cd4ddd603"
+  integrity sha512-59wvfx5vcCTHMeQT1/OwFiAj+UffLIwjRIoXdpO7Z7BCFGepzq9T9oLVeoItjTqjoXfUrHJvV7QU6pUR+UzOoA==
+
+jquery@^3.4.1:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
+  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
 
 js-base64@^2.1.8:
   version "2.6.4"


### PR DESCRIPTION
## 概要

activeadminを使用して管理画面を作成した。現時点ではUserモデルのみ管理対象となっている。
なお認証は初期設定ではDeviseを使用するようになっているが、sorceryを用いるよう設定を変更。
しかし、開発中はログインの手間を省くためログインを強制する処理はコメントアウトしている。
また、`enum_help`を導入しUserのenumの値をi18n対応させた。

## チェックリスト
- [x] 開発用adminユーザの作成
- [x] `activeadmin`の追加
- [x] 設定の変更
- [x] ユーザ管理画面の作成

closes #8