### PR TITLE
食品カテゴリー一覧ページを作成#18

### DIFF
--- a/app/controllers/api/v1/food_categories_controller.rb
+++ b/app/controllers/api/v1/food_categories_controller.rb
@@ -1,0 +1,12 @@
+module Api
+  module V1
+    class FoodCategoriesController < ApplicationController
+      def show
+        categories = FoodCategory.all
+        json_string = FoodCategorySerializer.new(categories).serialized_json
+
+        render json: json_string
+      end
+    end
+  end
+end

--- a/app/javascript/components/pages/FoodIndex.vue
+++ b/app/javascript/components/pages/FoodIndex.vue
@@ -1,0 +1,29 @@
+<template>
+  <v-tabs vertical>
+    <v-tab>
+      カテゴリー一覧
+    </v-tab>
+    <v-tab>
+      タグ一覧
+    </v-tab>
+
+    <v-tab-item>
+      <food-index-categories />
+    </v-tab-item>
+    <v-tab-item>
+      <p>
+        comming soon...
+      </p>
+    </v-tab-item>
+  </v-tabs>
+</template>
+
+<script>
+import FoodIndexCategories from '../parts/FoodIndexCategories';
+
+export default {
+  components: {
+    FoodIndexCategories
+  }
+};
+</script>

--- a/app/javascript/components/parts/FoodIndexCategories.vue
+++ b/app/javascript/components/parts/FoodIndexCategories.vue
@@ -1,0 +1,49 @@
+<template>
+  <div>
+    <template v-for="c in categories">
+      <v-btn
+        :key="c.id"
+        depressed
+        large
+        outlined
+        tile
+        height="80"
+        width="150"
+      >
+        {{ c.attributes.name }}
+      </v-btn>
+    </template>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      categories: {}
+    };
+  },
+  mounted() {
+    this.setCategories();
+  },
+  methods: {
+    setCategories() {
+      this.axios
+        .get('/api/v1/food_category')
+        .then(response => {
+          console.log(response.status);
+          this.categories = response.data.data;
+        })
+        .catch(error => {
+          console.error(error.response.status);
+        });
+    }
+  }
+};
+</script>
+
+<style scoped>
+.left {
+  float: left
+}
+</style>

--- a/app/javascript/components/parts/FooterMenuItemAfterLogin.vue
+++ b/app/javascript/components/parts/FooterMenuItemAfterLogin.vue
@@ -11,6 +11,15 @@
     </v-col>
     <v-col>
       <v-btn
+        :to="{ name: 'FoodIndex' }"
+        text
+        class="text-capitalize"
+      >
+        foods
+      </v-btn>
+    </v-col>
+    <v-col>
+      <v-btn
         :to="{ name: 'MyPage' }"
         text
         class="text-capitalize"

--- a/app/javascript/components/parts/FooterMenuItemBeforeLogin.vue
+++ b/app/javascript/components/parts/FooterMenuItemBeforeLogin.vue
@@ -21,6 +21,15 @@
     <v-col>
       <login-modal />
     </v-col>
+    <v-col>
+      <v-btn
+        :to="{ name: 'FoodIndex' }"
+        text
+        class="text-capitalize"
+      >
+        foods
+      </v-btn>
+    </v-col>
   </v-row>
 </template>
 

--- a/app/javascript/router/router.js
+++ b/app/javascript/router/router.js
@@ -5,6 +5,7 @@ import TopPage from '../components/pages/TopPage';
 import RegisterPage from '../components/pages/RegisterPage';
 import HomePage from '../components/pages/HomePage';
 import MyPage from '../components/pages/MyPage';
+import FoodIndex from '../components/pages/FoodIndex';
 
 Vue.use(VueRouter);
 
@@ -20,6 +21,11 @@ const router = new VueRouter({
       path: '/register',
       component: RegisterPage,
       name: 'RegisterPage'
+    },
+    {
+      path: '/search',
+      component: FoodIndex,
+      name: 'FoodIndex'
     },
     {
       path: '/home',

--- a/app/serializers/food_category_serializer.rb
+++ b/app/serializers/food_category_serializer.rb
@@ -1,0 +1,4 @@
+class FoodCategorySerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :id, :name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   namespace :api, format: 'json' do
     namespace :v1 do
       resource :registration, only: %i[create]
+      resource :food_category, only: %i[show]
       resource :authentication, only: %i[create destroy]
       resource :home, only: %i[index]
       resource :bmr, only: %i[show update]


### PR DESCRIPTION
## 概要

#17で作成した食品カテゴリーを一覧する画面を作成。
後に食品一覧画面につなげるためカテゴリーはボタンとして作成している。


## チェックリスト

- [x] `food_categories_controller`の作成
- [x] アクションの作成
- [x] ビューの作成
- [x] 動作確認

closes #18