### PR TITLE
食品一覧画面（カテゴリーごと）の作成#20

### DIFF
--- a/app/controllers/api/v1/food_categories_controller.rb
+++ b/app/controllers/api/v1/food_categories_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class FoodCategoriesController < ApplicationController
-      def show
+      def index
         categories = FoodCategory.all
         json_string = FoodCategorySerializer.new(categories).serialized_json
 

--- a/app/controllers/api/v1/foods_controller.rb
+++ b/app/controllers/api/v1/foods_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V1
+    class FoodsController < ApplicationController
+      def index
+        foods = Food.where(food_category_id: params[:food_category_id])
+        render json: foods
+      end
+
+      def show
+      end
+    end
+  end
+end

--- a/app/javascript/components/pages/FoodIndexByCategory.vue
+++ b/app/javascript/components/pages/FoodIndexByCategory.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <food-index-table
-      :headers="headers"
       :foods="foods"
     />
   </div>
@@ -16,27 +15,6 @@ export default {
   },
   data() {
     return {
-      headers: [
-        {
-          text: '食品名',
-          value: 'name',
-          align: 'end',
-          width: '10px'
-        },
-        {
-          text: '',
-          value: 'subname',
-          align: 'start',
-          width: '10px',
-          sortable: false
-        },
-        {
-          text: 'kcal',
-          value: 'calorie',
-          align: 'center',
-          width: '20px'
-        }
-      ],
       foods: []
     };
   },

--- a/app/javascript/components/pages/FoodIndexByCategory.vue
+++ b/app/javascript/components/pages/FoodIndexByCategory.vue
@@ -1,0 +1,60 @@
+<template>
+  <div>
+    <food-index-table
+      :headers="headers"
+      :foods="foods"
+    />
+  </div>
+</template>
+
+<script>
+import FoodIndexTable from '../parts/FoodIndexTable';
+
+export default {
+  components: {
+    FoodIndexTable
+  },
+  data() {
+    return {
+      headers: [
+        {
+          text: '食品名',
+          value: 'name',
+          align: 'end',
+          width: '10px'
+        },
+        {
+          text: '',
+          value: 'subname',
+          align: 'start',
+          width: '10px',
+          sortable: false
+        },
+        {
+          text: 'kcal',
+          value: 'calorie',
+          align: 'center',
+          width: '20px'
+        }
+      ],
+      foods: []
+    };
+  },
+  mounted() {
+    this.setFoods();
+  },
+  methods: {
+    setFoods() {
+      this.axios
+        .get(`/api/v1/food_categories/${this.$route.params.id}/foods`)
+        .then(res => {
+          console.log(res.status);
+          this.foods = res.data;
+        })
+        .catch(e => {
+          console.error(e.response.status);
+        });
+    }
+  }
+};
+</script>

--- a/app/javascript/components/parts/FoodIndexCategories.vue
+++ b/app/javascript/components/parts/FoodIndexCategories.vue
@@ -9,6 +9,7 @@
         tile
         height="80"
         width="150"
+        :to="{ name: 'FoodIndexByCategory', params: {id: c.id}}"
       >
         {{ c.attributes.name }}
       </v-btn>

--- a/app/javascript/components/parts/FoodIndexCategories.vue
+++ b/app/javascript/components/parts/FoodIndexCategories.vue
@@ -29,7 +29,7 @@ export default {
   methods: {
     setCategories() {
       this.axios
-        .get('/api/v1/food_category')
+        .get('/api/v1/food_categories')
         .then(response => {
           console.log(response.status);
           this.categories = response.data.data;

--- a/app/javascript/components/parts/FoodIndexTable.vue
+++ b/app/javascript/components/parts/FoodIndexTable.vue
@@ -1,0 +1,112 @@
+<template>
+  <v-data-iterator
+    :items="foods"
+    item-key="id"
+    loading
+    loading-text="loading..."
+  >
+    <v-row>
+      <v-col
+        v-for="food in foods"
+        :key="food.id"
+        cols="12"
+        sm="6"
+        md="4"
+      >
+        <v-card
+          flat
+          outlined
+          tile
+        >
+          <v-card-title>
+            <p>
+              <span class="text-subtitle-1">
+                {{ food.name }}
+              </span>
+              <span class="text-body-2">
+                {{ food.subname }}
+              </span>
+            </p>
+          </v-card-title>
+          <v-card-subtitle>
+            <p class="text-caption">
+              {{ food.calorie * food.reference_amount }}kcal / {{ food.reference_amount * 100 }}g
+            </p>
+          </v-card-subtitle>
+        </v-card>
+      </v-col>
+    </v-row>
+
+    <!-- <template v-slot:footer>
+      <v-row>
+        <p>表示件数</p>
+        <v-menu offset-y>
+          <template v-slot:activator="{ on, attrs }">
+            <v-btn
+              text
+              v-bind="attrs"
+              v-on="on"
+            >
+              {{ itemsPerPage }}
+              <v-icon>mdi-chevron-down</v-icon>
+            </v-btn>
+          </template>
+          <v-list>
+            <v-list-item
+              v-for="(num, index) in itemsPerPageArray"
+              :key="index"
+              @click="updateItemsPage(num)"
+            >
+              <v-list-item-title>{{ num }}</v-list-item-title>
+            </v-list-item>
+          </v-list>
+        </v-menu>
+        <p>{{ page }} / {{ numberOfPages }}</p>
+        <v-btn @click="formerPage">
+          <v-icon>mdi-chevron-left</v-icon>
+        </v-btn>
+        <v-btn @click="nextPage">
+          <v-icon>mdi-chevron-right</v-icon>
+        </v-btn>
+      </v-row>
+    </template> -->
+  </v-data-iterator>
+</template>
+
+<script>
+export default {
+  props: {
+    headers: {
+      type: Array,
+      default: () => ([])
+    },
+    foods: {
+      type: Array,
+      default: () => ([])
+    }
+  },
+  data() {
+    return {
+      itemsPerPage: 10,
+      itemsPerPageArray: [10, 20, 30],
+      page: 1
+    };
+  },
+  computed: {
+    numberOfPages() {
+      return Math.ceil(this.foods.length / this.itemsPerPage);
+    }
+  },
+  methods: {
+    nextPage() {
+      if (this.page + 1 <= this.numberOfPages) this.page += 1;
+    },
+    formerPage() {
+      if (this.page - 1 >= 1) this.page -=1;
+    },
+    updateItemsPerPage(num) {
+      this.itemsPerPage = num;
+    }
+  }
+};
+</script>

--- a/app/javascript/components/parts/FoodIndexTable.vue
+++ b/app/javascript/components/parts/FoodIndexTable.vue
@@ -36,76 +36,15 @@
         </v-card>
       </v-col>
     </v-row>
-
-    <!-- <template v-slot:footer>
-      <v-row>
-        <p>表示件数</p>
-        <v-menu offset-y>
-          <template v-slot:activator="{ on, attrs }">
-            <v-btn
-              text
-              v-bind="attrs"
-              v-on="on"
-            >
-              {{ itemsPerPage }}
-              <v-icon>mdi-chevron-down</v-icon>
-            </v-btn>
-          </template>
-          <v-list>
-            <v-list-item
-              v-for="(num, index) in itemsPerPageArray"
-              :key="index"
-              @click="updateItemsPage(num)"
-            >
-              <v-list-item-title>{{ num }}</v-list-item-title>
-            </v-list-item>
-          </v-list>
-        </v-menu>
-        <p>{{ page }} / {{ numberOfPages }}</p>
-        <v-btn @click="formerPage">
-          <v-icon>mdi-chevron-left</v-icon>
-        </v-btn>
-        <v-btn @click="nextPage">
-          <v-icon>mdi-chevron-right</v-icon>
-        </v-btn>
-      </v-row>
-    </template> -->
   </v-data-iterator>
 </template>
 
 <script>
 export default {
   props: {
-    headers: {
-      type: Array,
-      default: () => ([])
-    },
     foods: {
       type: Array,
       default: () => ([])
-    }
-  },
-  data() {
-    return {
-      itemsPerPage: 10,
-      itemsPerPageArray: [10, 20, 30],
-      page: 1
-    };
-  },
-  computed: {
-    numberOfPages() {
-      return Math.ceil(this.foods.length / this.itemsPerPage);
-    }
-  },
-  methods: {
-    nextPage() {
-      if (this.page + 1 <= this.numberOfPages) this.page += 1;
-    },
-    formerPage() {
-      if (this.page - 1 >= 1) this.page -=1;
-    },
-    updateItemsPerPage(num) {
-      this.itemsPerPage = num;
     }
   }
 };

--- a/app/javascript/router/router.js
+++ b/app/javascript/router/router.js
@@ -6,6 +6,7 @@ import RegisterPage from '../components/pages/RegisterPage';
 import HomePage from '../components/pages/HomePage';
 import MyPage from '../components/pages/MyPage';
 import FoodIndex from '../components/pages/FoodIndex';
+import FoodIndexByCategory from '../components/pages/FoodIndexByCategory';
 
 Vue.use(VueRouter);
 
@@ -26,6 +27,11 @@ const router = new VueRouter({
       path: '/search',
       component: FoodIndex,
       name: 'FoodIndex'
+    },
+    {
+      path: '/search/:id(\\d+)',
+      component: FoodIndexByCategory,
+      name: 'FoodIndexByCategory'
     },
     {
       path: '/home',

--- a/app/serializers/food_serializer.rb
+++ b/app/serializers/food_serializer.rb
@@ -1,0 +1,65 @@
+class FoodSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :name, :subname, :description, :reference_amount,
+             :protein, :fat, :carbohydrate,
+             :biotin, :calcium, :chromium, :copper, :folate, :iodine,
+             :iron, :magnesium, :manganese, :molybdenum, :niacin,
+             :pantothenic_acid, :phosphorus, :potassium, :selenium,
+             :vitamin_a, :vitamin_b1, :vitamin_b12, :vitamin_b2,
+             :vitamin_b6, :vitamin_c, :vitamin_d, :vitamin_e,
+             :vitamin_k, :zinc
+
+  belongs_to :food_category
+end
+
+# == Schema Information
+#
+# Table name: foods
+#
+#  id               :bigint           not null, primary key
+#  biotin           :float(24)        default(0.0), not null
+#  calcium          :float(24)        default(0.0), not null
+#  calorie          :float(24)        default(0.0), not null
+#  carbohydrate     :float(24)        default(0.0), not null
+#  chromium         :float(24)        default(0.0), not null
+#  copper           :float(24)        default(0.0), not null
+#  description      :text(65535)
+#  fat              :float(24)        default(0.0), not null
+#  folate           :float(24)        default(0.0), not null
+#  iodine           :float(24)        default(0.0), not null
+#  iron             :float(24)        default(0.0), not null
+#  magnesium        :float(24)        default(0.0), not null
+#  manganese        :float(24)        default(0.0), not null
+#  molybdenum       :float(24)        default(0.0), not null
+#  name             :string(255)      default("dummy"), not null
+#  niacin           :float(24)        default(0.0), not null
+#  pantothenic_acid :float(24)        default(0.0), not null
+#  phosphorus       :float(24)        default(0.0), not null
+#  potassium        :float(24)        default(0.0), not null
+#  priority         :integer          default(0), not null
+#  protein          :float(24)        default(0.0), not null
+#  reference_amount :float(24)        default(1.0), not null
+#  selenium         :float(24)        default(0.0), not null
+#  subname          :string(255)
+#  vitamin_a        :float(24)        default(0.0), not null
+#  vitamin_b1       :float(24)        default(0.0), not null
+#  vitamin_b12      :float(24)        default(0.0), not null
+#  vitamin_b2       :float(24)        default(0.0), not null
+#  vitamin_b6       :float(24)        default(0.0), not null
+#  vitamin_c        :float(24)        default(0.0), not null
+#  vitamin_d        :float(24)        default(0.0), not null
+#  vitamin_e        :float(24)        default(0.0), not null
+#  vitamin_k        :float(24)        default(0.0), not null
+#  zinc             :float(24)        default(0.0), not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  food_category_id :bigint
+#
+# Indexes
+#
+#  index_foods_on_food_category_id  (food_category_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (food_category_id => food_categories.id)
+#

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   namespace :api, format: 'json' do
     namespace :v1 do
       resource :registration, only: %i[create]
-      resources :food_categories, only: %i[index] 
+      resources :food_categories, only: %i[index] do
+        resources :foods, only: %i[index show]
+      end
       resource :authentication, only: %i[create destroy]
       resource :home, only: %i[index]
       resource :bmr, only: %i[show update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   namespace :api, format: 'json' do
     namespace :v1 do
       resource :registration, only: %i[create]
-      resource :food_category, only: %i[show]
+      resources :food_categories, only: %i[index] 
       resource :authentication, only: %i[create destroy]
       resource :home, only: %i[index]
       resource :bmr, only: %i[show update]
@@ -14,3 +14,85 @@ Rails.application.routes.draw do
     end
   end
 end
+
+# == Route Map
+#
+#                                       Prefix Verb   URI Pattern                                                                              Controller#Action
+#                                   admin_root GET    /admin(.:format)                                                                         admin/dashboard#index
+#                              admin_dashboard GET    /admin/dashboard(.:format)                                                               admin/dashboard#index
+# batch_action_admin_dietary_reference_intakes POST   /admin/dietary_reference_intakes/batch_action(.:format)                                  admin/dietary_reference_intakes#batch_action
+#              admin_dietary_reference_intakes GET    /admin/dietary_reference_intakes(.:format)                                               admin/dietary_reference_intakes#index
+#                                              POST   /admin/dietary_reference_intakes(.:format)                                               admin/dietary_reference_intakes#create
+#           new_admin_dietary_reference_intake GET    /admin/dietary_reference_intakes/new(.:format)                                           admin/dietary_reference_intakes#new
+#          edit_admin_dietary_reference_intake GET    /admin/dietary_reference_intakes/:id/edit(.:format)                                      admin/dietary_reference_intakes#edit
+#               admin_dietary_reference_intake GET    /admin/dietary_reference_intakes/:id(.:format)                                           admin/dietary_reference_intakes#show
+#                                              PATCH  /admin/dietary_reference_intakes/:id(.:format)                                           admin/dietary_reference_intakes#update
+#                                              PUT    /admin/dietary_reference_intakes/:id(.:format)                                           admin/dietary_reference_intakes#update
+#                                              DELETE /admin/dietary_reference_intakes/:id(.:format)                                           admin/dietary_reference_intakes#destroy
+#           batch_action_admin_food_categories POST   /admin/food_categories/batch_action(.:format)                                            admin/food_categories#batch_action
+#                        admin_food_categories GET    /admin/food_categories(.:format)                                                         admin/food_categories#index
+#                                              POST   /admin/food_categories(.:format)                                                         admin/food_categories#create
+#                      new_admin_food_category GET    /admin/food_categories/new(.:format)                                                     admin/food_categories#new
+#                     edit_admin_food_category GET    /admin/food_categories/:id/edit(.:format)                                                admin/food_categories#edit
+#                          admin_food_category GET    /admin/food_categories/:id(.:format)                                                     admin/food_categories#show
+#                                              PATCH  /admin/food_categories/:id(.:format)                                                     admin/food_categories#update
+#                                              PUT    /admin/food_categories/:id(.:format)                                                     admin/food_categories#update
+#                                              DELETE /admin/food_categories/:id(.:format)                                                     admin/food_categories#destroy
+#                     batch_action_admin_foods POST   /admin/foods/batch_action(.:format)                                                      admin/foods#batch_action
+#                                  admin_foods GET    /admin/foods(.:format)                                                                   admin/foods#index
+#                                              POST   /admin/foods(.:format)                                                                   admin/foods#create
+#                               new_admin_food GET    /admin/foods/new(.:format)                                                               admin/foods#new
+#                              edit_admin_food GET    /admin/foods/:id/edit(.:format)                                                          admin/foods#edit
+#                                   admin_food GET    /admin/foods/:id(.:format)                                                               admin/foods#show
+#                                              PATCH  /admin/foods/:id(.:format)                                                               admin/foods#update
+#                                              PUT    /admin/foods/:id(.:format)                                                               admin/foods#update
+#                                              DELETE /admin/foods/:id(.:format)                                                               admin/foods#destroy
+#                     batch_action_admin_users POST   /admin/users/batch_action(.:format)                                                      admin/users#batch_action
+#                                  admin_users GET    /admin/users(.:format)                                                                   admin/users#index
+#                                              POST   /admin/users(.:format)                                                                   admin/users#create
+#                               new_admin_user GET    /admin/users/new(.:format)                                                               admin/users#new
+#                              edit_admin_user GET    /admin/users/:id/edit(.:format)                                                          admin/users#edit
+#                                   admin_user GET    /admin/users/:id(.:format)                                                               admin/users#show
+#                                              PATCH  /admin/users/:id(.:format)                                                               admin/users#update
+#                                              PUT    /admin/users/:id(.:format)                                                               admin/users#update
+#                                              DELETE /admin/users/:id(.:format)                                                               admin/users#destroy
+#                               admin_comments GET    /admin/comments(.:format)                                                                admin/comments#index
+#                                              POST   /admin/comments(.:format)                                                                admin/comments#create
+#                                admin_comment GET    /admin/comments/:id(.:format)                                                            admin/comments#show
+#                                              DELETE /admin/comments/:id(.:format)                                                            admin/comments#destroy
+#                                         root GET    /                                                                                        top#index
+#                          api_v1_registration POST   /api/v1/registration(.:format)                                                           api/v1/registrations#create {:format=>/json/}
+#                   api_v1_food_category_foods GET    /api/v1/food_categories/:food_category_id/foods(.:format)                                api/v1/foods#index {:format=>/json/}
+#                    api_v1_food_category_food GET    /api/v1/food_categories/:food_category_id/foods/:id(.:format)                            api/v1/foods#show {:format=>/json/}
+#                       api_v1_food_categories GET    /api/v1/food_categories(.:format)                                                        api/v1/food_categories#index {:format=>/json/}
+#                        api_v1_authentication DELETE /api/v1/authentication(.:format)                                                         api/v1/authentications#destroy {:format=>/json/}
+#                                              POST   /api/v1/authentication(.:format)                                                         api/v1/authentications#create {:format=>/json/}
+#                                   api_v1_bmr GET    /api/v1/bmr(.:format)                                                                    api/v1/bmrs#show {:format=>/json/}
+#                                              PATCH  /api/v1/bmr(.:format)                                                                    api/v1/bmrs#update {:format=>/json/}
+#                                              PUT    /api/v1/bmr(.:format)                                                                    api/v1/bmrs#update {:format=>/json/}
+#                                   api_v1_pfc GET    /api/v1/pfc(.:format)                                                                    api/v1/pfcs#show {:format=>/json/}
+#                                              PATCH  /api/v1/pfc(.:format)                                                                    api/v1/pfcs#update {:format=>/json/}
+#                                              PUT    /api/v1/pfc(.:format)                                                                    api/v1/pfcs#update {:format=>/json/}
+#               api_v1_users_dietary_reference GET    /api/v1/users_dietary_reference(.:format)                                                api/v1/users_dietary_references#show {:format=>/json/}
+#                                              PATCH  /api/v1/users_dietary_reference(.:format)                                                api/v1/users_dietary_references#update {:format=>/json/}
+#                                              PUT    /api/v1/users_dietary_reference(.:format)                                                api/v1/users_dietary_references#update {:format=>/json/}
+#                rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format)                                  action_mailbox/ingresses/postmark/inbound_emails#create
+#                   rails_relay_inbound_emails POST   /rails/action_mailbox/relay/inbound_emails(.:format)                                     action_mailbox/ingresses/relay/inbound_emails#create
+#                rails_sendgrid_inbound_emails POST   /rails/action_mailbox/sendgrid/inbound_emails(.:format)                                  action_mailbox/ingresses/sendgrid/inbound_emails#create
+#          rails_mandrill_inbound_health_check GET    /rails/action_mailbox/mandrill/inbound_emails(.:format)                                  action_mailbox/ingresses/mandrill/inbound_emails#health_check
+#                rails_mandrill_inbound_emails POST   /rails/action_mailbox/mandrill/inbound_emails(.:format)                                  action_mailbox/ingresses/mandrill/inbound_emails#create
+#                 rails_mailgun_inbound_emails POST   /rails/action_mailbox/mailgun/inbound_emails/mime(.:format)                              action_mailbox/ingresses/mailgun/inbound_emails#create
+#               rails_conductor_inbound_emails GET    /rails/conductor/action_mailbox/inbound_emails(.:format)                                 rails/conductor/action_mailbox/inbound_emails#index
+#                                              POST   /rails/conductor/action_mailbox/inbound_emails(.:format)                                 rails/conductor/action_mailbox/inbound_emails#create
+#            new_rails_conductor_inbound_email GET    /rails/conductor/action_mailbox/inbound_emails/new(.:format)                             rails/conductor/action_mailbox/inbound_emails#new
+#           edit_rails_conductor_inbound_email GET    /rails/conductor/action_mailbox/inbound_emails/:id/edit(.:format)                        rails/conductor/action_mailbox/inbound_emails#edit
+#                rails_conductor_inbound_email GET    /rails/conductor/action_mailbox/inbound_emails/:id(.:format)                             rails/conductor/action_mailbox/inbound_emails#show
+#                                              PATCH  /rails/conductor/action_mailbox/inbound_emails/:id(.:format)                             rails/conductor/action_mailbox/inbound_emails#update
+#                                              PUT    /rails/conductor/action_mailbox/inbound_emails/:id(.:format)                             rails/conductor/action_mailbox/inbound_emails#update
+#                                              DELETE /rails/conductor/action_mailbox/inbound_emails/:id(.:format)                             rails/conductor/action_mailbox/inbound_emails#destroy
+#        rails_conductor_inbound_email_reroute POST   /rails/conductor/action_mailbox/:inbound_email_id/reroute(.:format)                      rails/conductor/action_mailbox/reroutes#create
+#                           rails_service_blob GET    /rails/active_storage/blobs/:signed_id/*filename(.:format)                               active_storage/blobs#show
+#                    rails_blob_representation GET    /rails/active_storage/representations/:signed_blob_id/:variation_key/*filename(.:format) active_storage/representations#show
+#                           rails_disk_service GET    /rails/active_storage/disk/:encoded_key/*filename(.:format)                              active_storage/disk#show
+#                    update_rails_disk_service PUT    /rails/active_storage/disk/:encoded_token(.:format)                                      active_storage/disk#update
+#                         rails_direct_uploads POST   /rails/active_storage/direct_uploads(.:format)                                           active_storage/direct_uploads#create


### PR DESCRIPTION
## 概要

食品カテゴリーごとの食品一覧画面を作成。
現状全データを一括で表示してしまって負担が高くなってしまっているため、
ページネーションもしくは無限スクロールなどの対応を行う必要あり。
また、URLの設計は再考の余地あり。


## チェックリスト

- [x] foodコントローラーの作成
- [x] シリアライザーの作成
- [x] アクションの実装
- [x] ルーティング定義
- [x] 一覧画面の作成
- [x] フロント処理の実装
- [x] 食品カテゴリからのリンク

closes #20