### PR TITLE
食事内容の提案作成するrakeタスクを実装#22

### DIFF
--- a/app/admin/dietary_reference_intakes.rb
+++ b/app/admin/dietary_reference_intakes.rb
@@ -1,4 +1,6 @@
 ActiveAdmin.register DietaryReferenceIntake do
+  actions :all, except: [:destroy]
+
   permit_params :gender, :age_top, :age_bottom, :vitamin_a, :upper_limit_vitamin_a,
                 :vitamin_d, :upper_limit_vitamin_d, :vitamin_e, :upper_limit_vitamin_e,
                 :vitamin_k, :vitamin_b1, :vitamin_b2, :niacin, :upper_limit_niacin,

--- a/app/admin/food_categories.rb
+++ b/app/admin/food_categories.rb
@@ -1,4 +1,6 @@
 ActiveAdmin.register FoodCategory do
+  actions :all, except: [:destroy]
+
   permit_params :name
 
   # 一覧ページの表示項目

--- a/app/admin/foods.rb
+++ b/app/admin/foods.rb
@@ -1,4 +1,6 @@
 ActiveAdmin.register Food do
+  actions :all, except: [:destroy]
+
   permit_params :id, :name, :subname, :food_category_id, :priority,
                 :reference_amount, :description,
                 :vitamin_a, :vitamin_d, :vitamin_e, :vitamin_k,
@@ -20,6 +22,7 @@ ActiveAdmin.register Food do
   end
 
   # 一覧ページのフィルター項目
+  filter :id
   filter :name
   filter :food_category_id
   filter :priority
@@ -34,6 +37,10 @@ ActiveAdmin.register Food do
       row(:priority)
       row(:reference_amount)
       row(:description)
+      row(:calorie)
+      row(:protein)
+      row(:fat)
+      row(:carbohydrate)
       row(:calcium)
       row(:magnesium)
       row(:phosphorus)

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -1,6 +1,16 @@
 class Food < ApplicationRecord
   # Associations
   belongs_to :food_category
+  has_many :suggestions, dependent: :destroy
+
+  # Scopes
+  scope :h_prio, -> { where(priority: 15) }
+  scope :m_prio, -> { where(priority: 10) }
+  scope :r_prio, -> { where(priority: 5) }
+  scope :rm_prio, -> { where(priority: [5, 10])}
+  scope :maindish, -> { where(food_category_id: [10, 11]) }
+  scope :staple_food, -> { where(food_category_id: [1, 2, 4]) }
+  scope :sidedish, -> { where(food_category_id: 5..9) }
 
   # Validations
   with_options presence: true do

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -7,7 +7,7 @@ class Food < ApplicationRecord
   scope :h_prio, -> { where(priority: 15) }
   scope :m_prio, -> { where(priority: 10) }
   scope :r_prio, -> { where(priority: 5) }
-  scope :rm_prio, -> { where(priority: [5, 10])}
+  scope :rm_prio, -> { where(priority: [5, 10]) }
   scope :maindish, -> { where(food_category_id: [10, 11]) }
   scope :staple_food, -> { where(food_category_id: [1, 2, 4]) }
   scope :sidedish, -> { where(food_category_id: 5..9) }

--- a/app/models/suggestion.rb
+++ b/app/models/suggestion.rb
@@ -1,0 +1,27 @@
+class Suggestion < ApplicationRecord
+end
+
+# == Schema Information
+#
+# Table name: suggestions
+#
+#  id          :bigint           not null, primary key
+#  amount      :float(24)        default(1.0), not null
+#  expies_at   :datetime         not null
+#  target_date :date             not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  food_id     :bigint           not null
+#  user_id     :bigint           not null
+#
+# Indexes
+#
+#  index_suggestions_on_food_id                              (food_id)
+#  index_suggestions_on_user_id                              (user_id)
+#  index_suggestions_on_user_id_and_food_id_and_target_date  (user_id,food_id,target_date) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (food_id => foods.id)
+#  fk_rails_...  (user_id => users.id)
+#

--- a/app/models/suggestion.rb
+++ b/app/models/suggestion.rb
@@ -1,4 +1,16 @@
 class Suggestion < ApplicationRecord
+  # Associations
+  belongs_to :user
+  belongs_to :food
+
+  # Validations
+  with_options presence: true do
+    validates :amount
+    validates :target_date
+    validates :expies_at
+  end
+
+  validates :user_id, uniqueness: { scope: [:food_id, :target_date] }
 end
 
 # == Schema Information

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,10 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
-  # Association
+  # Associations
   belongs_to :dietary_reference_intake
+  has_many :suggestions, dependent: :destroy
+  has_many :suggested_foods, through: :suggestions, source: :food
 
   # Enums
   enum gender: { female: 0, male: 10 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,13 +5,14 @@ Rails.application.routes.draw do
   namespace :api, format: 'json' do
     namespace :v1 do
       resource :registration, only: %i[create]
-      resources :food_categories, only: %i[index] do
-        resources :foods, only: %i[index show]
-      end
       resource :authentication, only: %i[create destroy]
+
       resource :home, only: %i[index]
       resource :bmr, only: %i[show update]
       resource :pfc, only: %i[show update]
+      resources :food_categories, only: %i[index] do
+        resources :foods, only: %i[index show]
+      end
       resource :users_dietary_reference, only: %i[show update]
     end
   end

--- a/db/migrate/20210916101150_create_suggestions.rb
+++ b/db/migrate/20210916101150_create_suggestions.rb
@@ -1,0 +1,15 @@
+class CreateSuggestions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :suggestions do |t|
+      t.references :user, foreign_key: true, null: false
+      t.references :food, foreign_key: true, null: false
+      t.float :amount, null: false, default: 1.0
+      t.date :target_date, null: false
+      t.datetime :expies_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :suggestions, [:user_id, :food_id, :target_date], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_15_030038) do
+ActiveRecord::Schema.define(version: 2021_09_16_101150) do
 
   create_table "active_admin_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "namespace"
@@ -123,6 +123,19 @@ ActiveRecord::Schema.define(version: 2021_09_15_030038) do
     t.index ["food_category_id"], name: "index_foods_on_food_category_id"
   end
 
+  create_table "suggestions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "food_id", null: false
+    t.float "amount", default: 1.0, null: false
+    t.date "target_date", null: false
+    t.datetime "expies_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["food_id"], name: "index_suggestions_on_food_id"
+    t.index ["user_id", "food_id", "target_date"], name: "index_suggestions_on_user_id_and_food_id_and_target_date", unique: true
+    t.index ["user_id"], name: "index_suggestions_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
@@ -145,5 +158,7 @@ ActiveRecord::Schema.define(version: 2021_09_15_030038) do
   end
 
   add_foreign_key "foods", "food_categories"
+  add_foreign_key "suggestions", "foods"
+  add_foreign_key "suggestions", "users"
   add_foreign_key "users", "dietary_reference_intakes"
 end

--- a/lib/tasks/suggestions.rake
+++ b/lib/tasks/suggestions.rake
@@ -17,21 +17,21 @@ namespace :suggestions do
           @total_cal += cal
         end
       end
-  
+
       User.find_each do |user|
         meal_menus = []
-  
+
         reg = Food.h_prio
         main = Food.m_prio.maindish.order(rand).limit(1)
         staple = Food.m_prio.staple_food.order(rand).limit(1)
-  
+
         meal_menus.concat(reg, main, staple)
         sum_calories(meal_menus)
-  
+
         bmr = user.bmr
-        while @total_cal <= bmr + 50 do
+        while @total_cal <= bmr + 50
           side = Food.rm_prio.sidedish.order(rand).limit(1)
-  
+
           # nextはrakeタスク内ではタスク自体の中断コマンド
           # ループのスキップとしては使えない？
           # とりあえずunless使用しておく
@@ -40,18 +40,18 @@ namespace :suggestions do
             sum_calories(meal_menus)
           end
         end
-  
+
         meal_menus.each do |m|
           item = user.suggestions.new(
             food_id: m.id,
             amount: m.reference_amount,
-            target_date: Date.today,
+            target_date: Time.zone.today,
             expies_at: Time.current.end_of_day
           )
-  
+
           item.save!
         end
-      end    
+      end
     }
   end
 end

--- a/lib/tasks/suggestions.rake
+++ b/lib/tasks/suggestions.rake
@@ -1,0 +1,57 @@
+namespace :suggestions do
+  desc "期限切れのsuggestionを削除"
+  task destroy_expied_suggestions: :environment do
+  end
+
+  desc "ユーザーごとに当日の食事内容を新規作成"
+  task create_suggestion: :environment do
+    require "benchmark"
+
+    puts Benchmark.measure {
+      rand = Rails.env.production? ? "RANDOM()" : "RAND()"
+
+      def sum_calories(foods)
+        @total_cal = 0
+        foods.each do |f|
+          cal = f.calorie * f.reference_amount
+          @total_cal += cal
+        end
+      end
+  
+      User.find_each do |user|
+        meal_menus = []
+  
+        reg = Food.h_prio
+        main = Food.m_prio.maindish.order(rand).limit(1)
+        staple = Food.m_prio.staple_food.order(rand).limit(1)
+  
+        meal_menus.concat(reg, main, staple)
+        sum_calories(meal_menus)
+  
+        bmr = user.bmr
+        while @total_cal <= bmr + 50 do
+          side = Food.rm_prio.sidedish.order(rand).limit(1)
+  
+          # nextはrakeタスク内ではタスク自体の中断コマンド
+          # ループのスキップとしては使えない？
+          # とりあえずunless使用しておく
+          unless meal_menus.include?(*side)
+            meal_menus.concat(side)
+            sum_calories(meal_menus)
+          end
+        end
+  
+        meal_menus.each do |m|
+          item = user.suggestions.new(
+            food_id: m.id,
+            amount: m.reference_amount,
+            target_date: Date.today,
+            expies_at: Time.current.end_of_day
+          )
+  
+          item.save!
+        end
+      end    
+    }
+  end
+end

--- a/spec/factories/suggestions.rb
+++ b/spec/factories/suggestions.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :suggestion do
-    
   end
 end
 

--- a/spec/factories/suggestions.rb
+++ b/spec/factories/suggestions.rb
@@ -1,0 +1,30 @@
+FactoryBot.define do
+  factory :suggestion do
+    
+  end
+end
+
+# == Schema Information
+#
+# Table name: suggestions
+#
+#  id          :bigint           not null, primary key
+#  amount      :float(24)        default(1.0), not null
+#  expies_at   :datetime         not null
+#  target_date :date             not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  food_id     :bigint           not null
+#  user_id     :bigint           not null
+#
+# Indexes
+#
+#  index_suggestions_on_food_id                              (food_id)
+#  index_suggestions_on_user_id                              (user_id)
+#  index_suggestions_on_user_id_and_food_id_and_target_date  (user_id,food_id,target_date) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (food_id => foods.id)
+#  fk_rails_...  (user_id => users.id)
+#

--- a/spec/models/suggestion_spec.rb
+++ b/spec/models/suggestion_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Suggestion, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end
+
+# == Schema Information
+#
+# Table name: suggestions
+#
+#  id          :bigint           not null, primary key
+#  amount      :float(24)        default(1.0), not null
+#  expies_at   :datetime         not null
+#  target_date :date             not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  food_id     :bigint           not null
+#  user_id     :bigint           not null
+#
+# Indexes
+#
+#  index_suggestions_on_food_id                              (food_id)
+#  index_suggestions_on_user_id                              (user_id)
+#  index_suggestions_on_user_id_and_food_id_and_target_date  (user_id,food_id,target_date) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (food_id => foods.id)
+#  fk_rails_...  (user_id => users.id)
+#


### PR DESCRIPTION
## 概要
ユーザー毎に設定されたBMRを基に、食事内容の提案を作成するrakeタスクを作成。
しかし処理内容は「とりあえず動く」だけの草案にしかなっていないため、
リファクタリングが必須である。
また、有効期限の過ぎた提案を削除する機能はまだ作成していない。

## チェックリスト

- [x] Suggestionsテーブル
- [x] モデルの作成
- [x] アソシエーションの定義
- [x] rakeタスクの作成
- [x] リントチェック

closes #22