### PR TITLE
gitignoreを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,7 +115,7 @@ bower.json
 .byebug_history
 
 # Ignore node_modules
-node_modules/
+/node_modules
 
 # Ignore precompiled javascript packs
 /public/packs
@@ -136,7 +136,6 @@ yarn-debug.log*
 
 /public/packs
 /public/packs-test
-/node_modules
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity


### PR DESCRIPTION
## 概要

Herokuへのデプロイ が失敗する原因の1つの可能性として、下記の記事を参考に
gitignoreを修正。

[Node.js のデプロイのトラブルシューティング](https://devcenter.heroku.com/ja/articles/troubleshooting-node-deploys#check-the-gitignore)

`node_modules/`となっておりすべてのサブディレクトリまで含めて除外する
記述になってしまっているのを、`/node_modules`に変更することで、
ルートディレクトリにのみマッチするよう変更。
